### PR TITLE
Add offline compression for DevStack compatibility

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,14 +1,15 @@
 ---
-dashboard_path: /opt/stack/horizon/openstack_dashboard/
+horizon_path: /opt/stack/horizon/
+dashboard_path: "{{ horizon_path }}openstack_dashboard/"
 dashboard_settings_file: "{{ dashboard_path }}settings.py"
 
 grafana_base_dir: /opt/stack
-grafana_dest: /opt/stack/horizon/static/grafana
+grafana_dest: "{{ horizon_path }}static/grafana"
 grafana_config: "{{ grafana_dest }}/config.js"
 grafana_version: master
 
 panel_src_path: /usr/local/lib/python2.7/dist-packages/monitoring/
-panel_dest_path: /opt/stack/horizon/monitoring
+panel_dest_path: "{{ horizon_path }}monitoring"
 
 ui_dest_path: "{{ dashboard_path }}local/enabled/"
 ui_src_path: "{{panel_src_path}}enabled/"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,5 +34,8 @@
 
 - meta: flush_handlers
 
+- name: UI - Update offline compression manifest
+  command: python {{ horizon_path }}manage.py compress --force
+
 - name: Enable apache
   service: name=apache2 state=started enabled=yes


### PR DESCRIPTION
Current pulls of DevStack cause the UI to fail with the error
`OfflineGenerationError at /`.  Offline compression is now enabled
by default, and the manifest needs to be updated for the UI to work.
The `--force` parameter is needed for backwards compatibility with
older devstack images (monasca-devstack VM 0.1.3 and prior).
