### PR TITLE
Limit offline compression to Devstack servers

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,8 +34,12 @@
 
 - meta: flush_handlers
 
+- stat: path={{horizon_path}}manage.py
+  register: horizon_manage
+
 - name: UI - Update offline compression manifest
   command: python {{ horizon_path }}manage.py compress --force
+  when: horizon_manage.stat.exists
 
 - name: Enable apache
   service: name=apache2 state=started enabled=yes


### PR DESCRIPTION
The offline compression task only needs to run on servers running
Devstack.  This change puts that restriction in place.
