### PR TITLE
Move Grafana to Apache's DocumentRoot

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ dashboard_path: "{{ horizon_path }}openstack_dashboard/"
 dashboard_settings_file: "{{ dashboard_path }}settings.py"
 
 grafana_base_dir: /opt/stack
-grafana_dest: "{{ horizon_path }}static/grafana"
+grafana_dest: "{{ apache_document_root }}grafana"
 grafana_config: "{{ grafana_dest }}/config.js"
 grafana_version: master
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,6 +44,10 @@
 - stat: path={{horizon_path}}manage.py
   register: horizon_manage
 
+- name: UI - Collect the static files
+  command: python {{ horizon_path }}manage.py collectstatic --noinput
+  when: horizon_manage.stat.exists
+
 - name: UI - Update offline compression manifest
   command: python {{ horizon_path }}manage.py compress --force
   when: horizon_manage.stat.exists

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,4 @@
 ---
 # The version to download will be appened to this.
 github_tarball_url: https://api.github.com/repos/hpcloud-mon/grafana/tarball
+apache_document_root: /var/www/html/


### PR DESCRIPTION
Static files are normally deployed with django's 'manage.py collectstatic'. When
run with --clear option, which seems to be default in some distributions (e.g.
RDO), all static resources are deleted first. Current Horizon integration
creates link to Grafana in static directory. Runing collectstatic --clear leaves
Grafana corrupted.

Proposed solution:
Move Grafana to Apache's DocumentRoot.

see also: https://review.openstack.org/#/c/258874/
