### PR TITLE
Fix Apache path to Grafana

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,15 @@
   notify:
     - restart apache
 
+- name: UI - Enable grafana in Apache
+  lineinfile:
+    dest: /etc/apache2/sites-available/horizon.conf
+    line: '    Alias /grafana {{ grafana_dest }}'
+    insertafter: ' Alias '
+    state: present
+  notify:
+    - restart apache
+
 - name: UI - Link grafana configuration
   file: src={{ grafana_dest }}/config.monasca.js dest={{ grafana_config }} state=link force=no
   when: untar | changed


### PR DESCRIPTION
Devstack VM version 0.2.0, with the latest Liberty code, broke
Grafana, throwing a 404 for /grafana/index.html.  This change
restores the Grafana URL by adding an alias to the Horizon config
in Apache.
